### PR TITLE
Region page: new LD source, pop selector, LZjs 0.10

### DIFF
--- a/pheweb/conf_utils.py
+++ b/pheweb/conf_utils.py
@@ -117,7 +117,7 @@ def _ensure_conf():
                         conf[key] = getattr(_conf_module, key)
     _load_config_file()
 
-    conf.set_default_value('lzjs_version', '0.9.0')  # Global setting, rarely needs configuration: which version of LZjs to fetch from the CDN
+    conf.set_default_value('lzjs_version', '0.10.0')  # Global setting, rarely needs configuration: which version of LZjs to fetch from the CDN
     conf.set_default_value('custom_templates', lambda: os.path.join(conf.data_dir, 'custom_templates'), is_function=True)
     conf.set_default_value('debug', False)
     conf.set_default_value('limit_num_variants', False)

--- a/pheweb/serve/static/region.js
+++ b/pheweb/serve/static/region.js
@@ -34,40 +34,6 @@ LocusZoom.KnownDataSources.extend("AssociationLZ", "AssociationPheWeb", {
     }
 });
 
-// Modified LD source that handles `NaN` in response.
-LocusZoom.KnownDataSources.extend("LDLZ", "LDPheweb", {
-    parseResponse: function (resp, chain, fields, outnames, trans) {
-        var json;
-        try {
-            json = JSON.parse(resp);
-        } catch (exc) {
-            if (exc instanceof SyntaxError) {
-                resp = resp.replace(/\bNaN\b/g, 'null');
-                var junk = JSON.parse(resp);
-                json = { data:{} };
-                Object.keys(junk).forEach(function(key) {
-                    if (key !== 'data') { json[key] = junk[key]; }
-                });
-                var json_data_keys = Object.keys(junk.data);
-                json_data_keys.forEach(function(key) {
-                    json.data[key] = [];
-                });
-                for (var i=0; i<junk.data.rsquare.length; i++) {
-                    if (junk.data.rsquare[i] !== null) {
-                        json_data_keys.forEach(function(key) {
-                            json.data[key].push(junk.data[key][i]);
-                        });
-                    }
-                }
-            } else {
-                console.error('Unhandled exception when processing LD source', exc);
-                throw exc;
-            }
-        }
-        return LocusZoom.Data.LDSource.prototype.parseResponse.call(this, json, chain, fields, outnames);
-    }
-});
-
 LocusZoom.TransformationFunctions.set("percent", function(x) {
     if (x === 1) { return "100%"; }
     x = (x * 100).toPrecision(2);
@@ -83,7 +49,9 @@ LocusZoom.TransformationFunctions.set("percent", function(x) {
     var data_sources = new LocusZoom.DataSources()
         .add("assoc", ["AssociationPheWeb", localBase])
         .add("catalog", ["GwasCatalogLZ", {url: remoteBase + 'annotation/gwascatalog/results/', params: { source: 2, build: "GRCh37" }}])
-        .add("ld", ["LDPheweb", {url: remoteBase + "pair/LD/", params: { pvalue_field: "assoc:pvalue|neglog10_or_100" }}])
+        .add("ld", ["LDLZ2", { url: "https://portaldev.sph.umich.edu/ld/",
+            params: { source: '1000G', build: 'GRCh37', population: 'ALL' }
+        }])
         .add("gene", ["GeneLZ", { url: remoteBase + "annotation/genes/", params: {source: 2} }])
         .add("recomb", ["RecombLZ", { url: remoteBase + "annotation/recomb/results/", params: {source: 15} }]);
 
@@ -108,35 +76,6 @@ LocusZoom.TransformationFunctions.set("percent", function(x) {
             }
             if (layout.class){ this.selector.attr("class", layout.class); }
             if (layout.style){ this.selector.style(layout.style); }
-            return this;
-        };
-    });
-
-    LocusZoom.Dashboard.Components.add("ldrefsource_selector", function(layout){
-        LocusZoom.Dashboard.Component.apply(this, arguments);
-        this.initialize = function(){
-            this.parent_plot.state.ldrefsource = 1;
-        };
-
-        this.update = function() {
-            if (this.button){ return this; }
-
-            this.button = new LocusZoom.Dashboard.Component.Button(this);
-            this.button
-                .setHtml("LD source: 1000G ALL")
-                .setTitle("click to switch to next LD source")
-                .setOnclick(function(){
-                    if (this.parent_plot.state.ldrefsource === 1) {
-                        this.parent_plot.state.ldrefsource = 2;
-                        this.button.setHtml('LD source: 1000G EUR');
-                    } else {
-                        this.parent_plot.state.ldrefsource = 1;
-                        this.button.setHtml('LD source: 1000G ALL');
-                    }
-                    this.button.show();
-                    this.parent_plot.applyState({});
-                }.bind(this));
-            this.button.show();
             return this;
         };
     });
@@ -227,10 +166,7 @@ LocusZoom.TransformationFunctions.set("percent", function(x) {
             },{
                 "type": "download",
                 "position": "right"
-            },{
-                "type": "ldrefsource_selector",
-                "position": "right"
-            }]
+            }, LocusZoom.Layouts.get('dashboard_components', 'ldlz2_pop_selector')]
         },
         panels: [
             function() {

--- a/pheweb/serve/static/variant.js
+++ b/pheweb/serve/static/variant.js
@@ -7,60 +7,81 @@ function deepcopy(obj) {
 function custom_LocusZoom_Layouts_get(layout_type, layout_name, customizations) {
     // Similar to `LocusZoom.Layouts.get` but also accepts keys like "axes.x.ticks"
     var layout = LocusZoom.Layouts.get(layout_type, layout_name);
-    Object.keys(customizations).forEach(function(key) {
+    Object.keys(customizations).forEach(function (key) {
         var value = customizations[key];
         if (!key.includes(".")) {
             layout[key] = value;
         } else {
             var key_parts = key.split(".");
             var obj = layout;
-            for (var i=0; i < key_parts.length-1; i++) {
+            for (var i = 0; i < key_parts.length - 1; i++) {
                 // TODO: check that `obj` contains `key_parts[i]`
                 obj = obj[key_parts[i]];
             }
-            obj[key_parts[key_parts.length-1]] = value;
+            obj[key_parts[key_parts.length - 1]] = value;
         }
     });
     return layout;
 }
 
-LocusZoom.TransformationFunctions.set("percent", function(x) {
-    if (x === 1) { return "100%"; }
+LocusZoom.TransformationFunctions.set("percent", function (x) {
+    if (x === 1) {
+        return "100%";
+    }
     x = (x * 100).toPrecision(2);
-    if (x.indexOf('.') !== -1) { x = x.replace(/0+$/, ''); }
-    if (x.endsWith('.')) { x = x.substr(0, x.length-1); }
+    if (x.indexOf('.') !== -1) {
+        x = x.replace(/0+$/, '');
+    }
+    if (x.endsWith('.')) {
+        x = x.substr(0, x.length - 1);
+    }
     return x + '%';
 });
 
-LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
-    if (typeof input === "undefined"){
+LocusZoom.ScaleFunctions.add("effect_direction", function (parameters, input) {
+    if (typeof input === "undefined") {
         return null;
     } else if (!isNaN(input.beta)) {
         if (!isNaN(input.sebeta)) {
-            if      (input.beta - 2*input.sebeta > 0) { return parameters['+'] || null; }
-            else if (input.beta + 2*input.sebeta < 0) { return parameters['-'] || null; }
+            if (input.beta - 2 * input.sebeta > 0) {
+                return parameters['+'] || null;
+            } else if (input.beta + 2 * input.sebeta < 0) {
+                return parameters['-'] || null;
+            }
         } else {
-            if      (input.beta > 0) { return parameters['+'] || null; }
-            else if (input.beta < 0) { return parameters['-'] || null; }
+            if (input.beta > 0) {
+                return parameters['+'] || null;
+            } else if (input.beta < 0) {
+                return parameters['-'] || null;
+            }
         }
     } else if (!isNaN(input.or)) {
-        if      (input.or > 0) { return parameters['+'] || null; }
-        else if (input.or < 0) { return parameters['-'] || null; }
+        if (input.or > 0) {
+            return parameters['+'] || null;
+        } else if (input.or < 0) {
+            return parameters['-'] || null;
+        }
     }
     return null;
 });
 
-(function() {
+(function () {
     // sort phenotypes
-    if (_.any(window.variant.phenos.map(function(d) { return d.phenocode; }).map(parseFloat).map(isNaN))) {
-        window.variant.phenos = _.sortBy(window.variant.phenos, function(d) { return d.phenocode; });
+    if (_.any(window.variant.phenos.map(function (d) {
+        return d.phenocode;
+    }).map(parseFloat).map(isNaN))) {
+        window.variant.phenos = _.sortBy(window.variant.phenos, function (d) {
+            return d.phenocode;
+        });
     } else {
-        window.variant.phenos = _.sortBy(window.variant.phenos, function(d) { return parseFloat(d.phenocode); });
+        window.variant.phenos = _.sortBy(window.variant.phenos, function (d) {
+            return parseFloat(d.phenocode);
+        });
     }
 
-    window.first_of_each_category = (function() {
+    window.first_of_each_category = (function () {
         var categories_seen = {};
-        return window.variant.phenos.filter(function(pheno) {
+        return window.variant.phenos.filter(function (pheno) {
             if (categories_seen.hasOwnProperty(pheno.category)) {
                 return false;
             } else {
@@ -69,22 +90,22 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
             }
         });
     })();
-    var category_order = (function() {
+    var category_order = (function () {
         var rv = {};
-        first_of_each_category.forEach(function(pheno, i) {
+        first_of_each_category.forEach(function (pheno, i) {
             rv[pheno.category] = i;
         });
         return rv;
     })();
     // _.sortBy is a stable sort, so we just sort by category_order and we're good.
-    window.variant.phenos = _.sortBy(window.variant.phenos, function(d) {
+    window.variant.phenos = _.sortBy(window.variant.phenos, function (d) {
         return category_order[d.category];
     });
     window.unique_categories = d3.set(window.variant.phenos.map(_.property('category'))).values();
-    window.color_by_category = ((unique_categories.length>10) ? d3.scale.category20() : d3.scale.category10())
+    window.color_by_category = ((unique_categories.length > 10) ? d3.scale.category20() : d3.scale.category10())
         .domain(unique_categories);
 
-    window.variant.phenos.forEach(function(d, i) {
+    window.variant.phenos.forEach(function (d, i) {
         d.phewas_code = d.phenocode;
         d.phewas_string = (d.phenostring || d.phenocode);
         d.category_name = d.category;
@@ -94,45 +115,49 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
 })();
 
 
-(function() { // Create PheWAS plot.
+(function () { // Create PheWAS plot.
 
-    var best_neglog10_pval = d3.max(window.variant.phenos.map(function(x) { return LocusZoom.TransformationFunctions.get('neglog10')(x.pval); }));
-    var neglog10_handle0 = function(x) {
+    var best_neglog10_pval = d3.max(window.variant.phenos.map(function (x) {
+        return LocusZoom.TransformationFunctions.get('neglog10')(x.pval);
+    }));
+    var neglog10_handle0 = function (x) {
         if (x === 0) return best_neglog10_pval * 1.1;
         return -Math.log(x) / Math.LN10;
     };
     LocusZoom.TransformationFunctions.set("neglog10_handle0", neglog10_handle0);
 
     // Define data sources object
-    LocusZoom.Data.PheWASSource.prototype.getData = function(state, fields, outnames, trans) {
+    LocusZoom.Data.PheWASSource.prototype.getData = function (state, fields, outnames, trans) {
         // Override all parsing, namespacing, and field extraction mechanisms, and load data embedded within the page
         trans = trans || [];
 
         var data = deepcopy(window.variant.phenos); //otherwise LZ adds attributes I don't want to the original data.
-        data.forEach(function(d, i) {
+        data.forEach(function (d, i) {
             data[i].x = i;
             data[i].id = i.toString();
-            trans.forEach(function(transformation, t){
-                if (typeof transformation === "function"){
+            trans.forEach(function (transformation, t) {
+                if (typeof transformation === "function") {
                     data[i][outnames[t]] = transformation(data[i][fields[t]]);
                 }
             });
         });
-        return function(chain) {
-            return {header: chain.header || {}, body: data};
+        return function (chain) {
+            return { header: chain.header || {}, body: data };
         }.bind(this);
     };
     var data_sources = new LocusZoom.DataSources()
-      .add("phewas", ["PheWASLZ", {url: '/this/is/not/used'}]);
+        .add("phewas", ["PheWASLZ", { url: '/this/is/not/used' }]);
 
     var neglog10_significance_threshold = -Math.log10(0.05 / window.variant.phenos.length);
 
     var layout = {
         state: {
-            variant: ['chrom', 'pos', 'ref', 'alt'].map(function(d) { return window.variant[d];}).join("-"),
+            variant: ['chrom', 'pos', 'ref', 'alt'].map(function (d) {
+                return window.variant[d];
+            }).join("-"),
         },
         dashboard: {
-            components: [{type: "download", position: "right"}],
+            components: [{ type: "download", position: "right" }],
         },
         min_height: 400,
         responsive_resize: "width_only",
@@ -153,7 +178,9 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
                         scale_function: "categorical_bin",
                         parameters: {
                             categories: window.unique_categories,
-                            values: window.unique_categories.map(function(cat) { return window.color_by_category(cat); }),
+                            values: window.unique_categories.map(function (cat) {
+                                return window.color_by_category(cat);
+                            }),
                         },
                     },
                     point_shape: [
@@ -168,36 +195,44 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
                     ],
                     "y_axis.field": 'pval|neglog10_handle0',  // handles pval=0 a little better
                     "y_axis.upper_buffer": 0.1,
-                    "y_axis.min_extent": [0, neglog10_significance_threshold*1.05], // always show sig line
+                    "y_axis.min_extent": [0, neglog10_significance_threshold * 1.05], // always show sig line
 
                     "x_axis.min_extent": [-1, window.variant.phenos.length], // a little x-padding so that no points intersect the edge
 
                     "tooltip.closable": false,
                     "tooltip.html": ("<div><strong>{{phewas_string}}</strong></div>\n" +
-                                     "<div><strong style='color:{{color}}'>{{category_name}}</strong></div>\n\n" +
-                                     window.model.tooltip_lztemplate),
+                        "<div><strong style='color:{{color}}'>{{category_name}}</strong></div>\n\n" +
+                        window.model.tooltip_lztemplate),
 
                     // Show labels that are: in the top 10, and (by neglog10) >=75% of sig threshold, and >=25% of best
                     "label.text": "{{phewas_string}}",
-                    "label.filters": (function() {
+                    "label.filters": (function () {
                         var ret = [
-                            {field:"pval|neglog10_handle0", operator:">", value:neglog10_significance_threshold * 3/4},
-                            {field:"pval|neglog10_handle0", operator:">", value:best_neglog10_pval / 4}
+                            {
+                                field: "pval|neglog10_handle0",
+                                operator: ">",
+                                value: neglog10_significance_threshold * 3 / 4
+                            },
+                            { field: "pval|neglog10_handle0", operator: ">", value: best_neglog10_pval / 4 }
                         ];
                         if (window.variant.phenos.length > 10) {
-                            ret.push({field:"pval", operator:"<", value:_.sortBy(window.variant.phenos.map(_.property('pval')))[10]});
+                            ret.push({
+                                field: "pval",
+                                operator: "<",
+                                value: _.sortBy(window.variant.phenos.map(_.property('pval')))[10]
+                            });
                         }
                         return ret;
                     })(),
 
-                    "behaviors.onclick": [{action:"link", href:window.model.urlprefix+"/pheno/{{phewas_code}}"}],
+                    "behaviors.onclick": [{ action: "link", href: window.model.urlprefix + "/pheno/{{phewas_code}}" }],
                 }),
             ],
 
             // Use categories as x ticks.
-            "axes.x.ticks": window.first_of_each_category.map(function(pheno) {
+            "axes.x.ticks": window.first_of_each_category.map(function (pheno) {
                 return {
-                    style: {fill: pheno.color, "font-size":"11px", "font-weight":"bold", "text-anchor":"start"},
+                    style: { fill: pheno.color, "font-size": "11px", "font-weight": "bold", "text-anchor": "start" },
                     transform: "translate(15, 0) rotate(50)",
                     text: pheno.category,
                     x: pheno.idx
@@ -208,31 +243,41 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
         })]
     };
 
-    $(function() {
+    $(function () {
         window.debug.plot = LocusZoom.populate("#phewas_plot_container", data_sources, layout);
     });
 })();
 
 
 // Check MAF/AF/AC and render
-(function() {
-    var isnum = function(d) { return typeof d === "number"; };
-    var mafs = window.variant.phenos.map(function(v) {
-        if (isnum(v.maf))  { return v.maf; }
-        else if (isnum(v.af)) { return Math.min(v.af, 1-v.af); }
-        else if (isnum(v.ac) && isnum(v.num_samples)) { var af = v.ac / (2*v.num_samples); return Math.min(af,1-af); }
-        else { return undefined; }
+(function () {
+    var isnum = function (d) {
+        return typeof d === "number";
+    };
+    var mafs = window.variant.phenos.map(function (v) {
+        if (isnum(v.maf)) {
+            return v.maf;
+        } else if (isnum(v.af)) {
+            return Math.min(v.af, 1 - v.af);
+        } else if (isnum(v.ac) && isnum(v.num_samples)) {
+            var af = v.ac / (2 * v.num_samples);
+            return Math.min(af, 1 - af);
+        } else {
+            return undefined;
+        }
     });
-    var num_phenos_with_maf = _.filter(mafs, function(d) { return isnum(d) }).length;
+    var num_phenos_with_maf = _.filter(mafs, function (d) {
+        return isnum(d)
+    }).length;
     if (num_phenos_with_maf === mafs.length) {
         var range = d3.extent(mafs);
-        $(function() {
+        $(function () {
             $('#maf-range').html('<p>MAF ranges from ' + two_digit_format(range[0]) + ' to ' + two_digit_format(range[1]) + '</p>');
             $('#maf-range p').css('margin-bottom', '0');
         });
     } else if (num_phenos_with_maf > 0) {
         var range = d3.extent(mafs);
-        $(function() {
+        $(function () {
             $('#maf-range').html('<p>MAF ranges from ' + two_digit_format(range[0]) + ' to ' + two_digit_format(range[1]) + ' for phenotypes where it is defined</p>');
             $('#maf-range p').css('margin-bottom', '0');
         });
@@ -241,14 +286,14 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
 
 
 // Check Clinvar and render link.
-(function() {
+(function () {
     var clinvar_api_template = _.template('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=<%= chrom %>[Chromosome]%20AND%20<%= pos %>[Base%20Position%20for%20Assembly%20GRCh37]&retmode=json');
     var clinvar_api_url = clinvar_api_template(window.variant);
 
     var clinvar_link_template = _.template('https://www.ncbi.nlm.nih.gov/clinvar?term=<%= chrom %>[Chromosome]%20AND%20<%= pos %>[Base%20Position%20for%20Assembly%20GRCh37]');
     var clinvar_link_url = clinvar_link_template(window.variant);
 
-    $.getJSON(clinvar_api_url).done(function(result) {
+    $.getJSON(clinvar_api_url).done(function (result) {
         if (result.esearchresult.count !== "0") {
             // It's in ClinVar
             $('#clinvar-link').html(', <a href="{URL}" target="_blank">Clinvar</a>'.replace('{URL}', clinvar_link_url));
@@ -259,34 +304,34 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
 
 // Check PubMed for each rsid and render link.
 if (typeof window.variant.rsids !== "undefined") {
-    (function() {
+    (function () {
         var pubmed_api_template = _.template('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&retmax=1&retmode=xml&term=<%= rsid %>');
         var pubmed_link_template = _.template('https://www.ncbi.nlm.nih.gov/pubmed/?term=<%= rsid %>');
         var rsids = window.variant.rsids.split(','); // There's usually just one rsid.
-        rsids.forEach(function(rsid) {
-            var pubmed_api_url = pubmed_api_template({rsid: rsid});
-            var pubmed_link_url = pubmed_link_template({rsid: rsid});
+        rsids.forEach(function (rsid) {
+            var pubmed_api_url = pubmed_api_template({ rsid: rsid });
+            var pubmed_link_url = pubmed_link_template({ rsid: rsid });
 
             $.ajax({
                 url: pubmed_api_url,
                 datatype: 'xml',
-            }).done(function(result) {
+            }).done(function (result) {
                 // window.rv = result;
                 var count_elem = result.querySelector('eSearchResult Count');
                 var num_pubmed_results = (count_elem === null) ? 0 : parseInt(count_elem.textContent);
                 if (num_pubmed_results > 0) {
                     if (rsids.length === 1) {
                         $('#pubmed-link').html(', <a href="{URL}" target="_blank">PubMed ({NUM} results)</a>'
-                                               .replace('{URL}', pubmed_link_url)
-                                               .replace('{NUM}', num_pubmed_results));
+                            .replace('{URL}', pubmed_link_url)
+                            .replace('{NUM}', num_pubmed_results));
                     } else {
                         $('#pubmed-link').html(', <a href="{URL}" target="_blank">PubMed for {RSID} ({NUM} results)</a>'
-                                               .replace('{URL}', pubmed_link_url)
-                                               .replace('{RSID}', rsid)
-                                               .replace('{NUM}', num_pubmed_results));
+                            .replace('{URL}', pubmed_link_url)
+                            .replace('{RSID}', rsid)
+                            .replace('{NUM}', num_pubmed_results));
                     }
                 }
-            }).fail(function(obj) {
+            }).fail(function (obj) {
                 console.log(['XHR for PubMed failed!', obj]);
             });
         });
@@ -295,19 +340,21 @@ if (typeof window.variant.rsids !== "undefined") {
 
 
 // Populate StreamTable
-$(function() {
+$(function () {
     // This is mostly copied from <https://michigangenomics.org/health_data.html>.
-    var data = _.sortBy(window.variant.phenos, function(pheno) { return pheno.pval; });
+    var data = _.sortBy(window.variant.phenos, function (pheno) {
+        return pheno.pval;
+    });
     var template = _.template($('#streamtable-template').html());
-    var view = function(phenotype) {
-        return template({d: phenotype});
+    var view = function (phenotype) {
+        return template({ d: phenotype });
     };
     var $found = $('#streamtable-found');
     $found.text(data.length + " total phenotypes");
 
     var callbacks = {
-        pagination: function(summary){
-            if ($.trim($('#search').val()).length > 0){
+        pagination: function (summary) {
+            if ($.trim($('#search').val()).length > 0) {
                 $found.text(summary.total + " matching codes");
             } else {
                 $found.text(data.length + " total codes");


### PR DESCRIPTION
Ticket: #128 

## Purpose
The old LD server is deprecated, but collectively, newly created PheWebs represent a major source of traffic.

We should update PheWeb to use the new LD server, including features such as the new "choose LD population" picker with more available populations.

# How to test this
- Variant page: PheWAS plot was converted to modern category scatter. It should display normally, and respect all common options for variant data (I tried this only with the very small amount of test data available to devs). I have removed some of the extra code around data loading; make sure I didn't remove anything important!
- Region page: LD population selector should appear on toolbar. Plot should update when options are chosen. LD information should color correctly
- Did I miss any important pages?