### PR TITLE
Fix download gene URL (ftp site closed)

### DIFF
--- a/pheweb/load/download_genes.py
+++ b/pheweb/load/download_genes.py
@@ -161,7 +161,7 @@ def run(argv):
         if not os.path.exists(gencode_filepath):
             make_basedir(gencode_filepath)
             wget.download(
-                url="ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{0}/GRCh37_mapping/gencode.v{0}lift37.annotation.gtf.gz".format(genes_version),
+                url="http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{0}/GRCh37_mapping/gencode.v{0}lift37.annotation.gtf.gz".format(genes_version),
                 out=gencode_filepath
             )
             print('')


### PR DESCRIPTION
An simple fix to the download gene URL, seems the ftp site of ebi.ac.uk has been closed.  I have tested the http site, it works without problem. 