### PR TITLE
Upgrade to LZ JS 0.13

### DIFF
--- a/pheweb/conf.py
+++ b/pheweb/conf.py
@@ -160,8 +160,8 @@ def get_pheno_correlations_pvalue_threshold() -> float: return _get_config_float
 
 
 ## Serving config
-def get_lzjs_version() -> str: return _get_config_str('lzjs_version', '0.10.2')
-def get_lzjs_version_phewas() -> str: return _get_config_str('lzjs_version_phewas', '0.9.0')
+def get_lzjs_version() -> str: return _get_config_str('lzjs_version', '0.13.0')
+def get_lzjs_version_phewas() -> str: return _get_config_str('lzjs_version_phewas', '0.13.0')
 def should_allow_variant_json_cors() -> bool: return _get_config_bool('allow_variant_json_cors', True)
 def get_urlprefix() -> str: return _get_config_str('urlprefix', '').rstrip('/')
 def get_custom_templates_dir() -> Optional[str]:

--- a/pheweb/conf.py
+++ b/pheweb/conf.py
@@ -161,7 +161,6 @@ def get_pheno_correlations_pvalue_threshold() -> float: return _get_config_float
 
 ## Serving config
 def get_lzjs_version() -> str: return _get_config_str('lzjs_version', '0.13.0')
-def get_lzjs_version_phewas() -> str: return _get_config_str('lzjs_version_phewas', '0.13.0')
 def should_allow_variant_json_cors() -> bool: return _get_config_bool('allow_variant_json_cors', True)
 def get_urlprefix() -> str: return _get_config_str('urlprefix', '').rstrip('/')
 def get_custom_templates_dir() -> Optional[str]:

--- a/pheweb/parse_utils.py
+++ b/pheweb/parse_utils.py
@@ -82,8 +82,8 @@ per_assoc_fields: Dict[str,Dict[str,Any]] = {
         'sigfigs': 2,
         'tooltip_lztemplate': {
             'condition': False,
-            'template': ('{{#if pvalue}}P-value: <strong>{{pvalue|scinotation}}</strong><br>{{/if}}\n' +
-                         '{{#if pval}}P-value: <strong>{{pval|scinotation}}</strong><br>{{/if}}'),
+            'template': ('{{#if pvalue|is_numeric}}P-value: <strong>{{pvalue|scinotation}}</strong><br>{{/if}}\n' +
+                         '{{#if pval|is_numeric}}P-value: <strong>{{pval|scinotation}}</strong><br>{{/if}}'),
         },
         'display': 'P-value',
     },
@@ -92,7 +92,7 @@ per_assoc_fields: Dict[str,Dict[str,Any]] = {
         'nullable': True,
         'sigfigs': 2,
         'tooltip_underscoretemplate': 'Beta: <b><%= d.beta %></b><% if(_.has(d, "sebeta")){ %> (se:<b><%= d.sebeta %></b>)<% } %><br>',
-        'tooltip_lztemplate': 'Beta: <strong>{{beta}}</strong>{{#if sebeta}} (se:<strong>{{sebeta}}</strong>){{/if}}<br>',
+        'tooltip_lztemplate': 'Beta: <strong>{{beta}}</strong>{{#if sebeta|is_numeric}} (se:<strong>{{sebeta}}</strong>){{/if}}<br>',
         'display': 'Beta',
     },
     'sebeta': {

--- a/pheweb/serve/server.py
+++ b/pheweb/serve/server.py
@@ -39,7 +39,6 @@ app.config['HG_BUILD_NUMBER'] = conf.get_hg_build_number()
 app.config['GRCH_BUILD_NUMBER'] = conf.get_grch_build_number()
 app.config['PHEWEB_VERSION'] = pheweb_version
 app.config['LZJS_VERSION'] = conf.get_lzjs_version()
-app.config['LZJS_VERSION_PHEWAS'] = conf.get_lzjs_version_phewas()
 app.config['URLPREFIX'] = conf.get_urlprefix()
 app.config['USE_WHITELIST'] = conf.is_login_required() and bool(conf.get_login_allowlist())
 if conf.get_custom_templates_dir():

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -1,8 +1,14 @@
-.lz-dashboard.lz-plot-dashboard { text-align: center; }
-.lz-dashboard-left, .lz-dashboard-right { display: inline-block; }
-.lz-dashboard-group-start, .lz-dashboard-group-middle, .lz-dashboard-group-end { float: none !important; }
+.lz-toolbar.lz-plot-toolbar {
+    text-align: center;
+}
+.lz-toolbar-left, .lz-toolbar-right {
+    display: inline-block;
+}
+.lz-toolbar-group-start, .lz-toolbar-group-middle, .lz-toolbar-group-end {
+    float: none !important;
+}
 /*
-TODO: merge dashboard-component-centering into LZ. (should it be the default?)
-      - if not, make it explicit.  it's bad that I'm just centering anything with `.lz-dashboard-group-*`.
+TODO: merge toolbar-component-centering into LZ. (should it be the default?)
+      - if not, make it explicit.  it's bad that I'm just centering anything with `.lz-toolbar-group-*`.
 TODO: stop text-align:center from cascading downward through descendants
 */

--- a/pheweb/serve/static/region.js
+++ b/pheweb/serve/static/region.js
@@ -98,7 +98,7 @@ LocusZoom.TransformationFunctions.add("percent", function(x) {
         unnamespaced: true,
         width: 800,
         // height: 550,
-        responsive_resize: 'width_only',
+        responsive_resize: true,
         max_region_scale: 500e3,
         toolbar: {
             widgets: [{
@@ -276,7 +276,7 @@ LocusZoom.TransformationFunctions.add("percent", function(x) {
                                         "<br>" +
                                         "<a href=\"" + window.model.urlprefix+ "/variant/{{{{namespace[assoc]}}chr}}-{{{{namespace[assoc]}}position}}-{{{{namespace[assoc]}}ref}}-{{{{namespace[assoc]}}alt}}\"" + ">Go to PheWAS</a>" +
                                         "{{#if {{namespace[catalog]}}rsid}}<br><a href=\"https://www.ebi.ac.uk/gwas/search?query={{{{namespace[catalog]}}rsid}}\" target=\"_new\">See hits in GWAS catalog</a>{{/if}}" +
-                                        "<br><a href=\"javascript:void(0);\" onclick=\"LocusZoom.getToolTipDataLayer(this).makeLDReference(LocusZoom.getToolTipData(this));\">Make LD Reference</a>"
+                                        "<br>{{#if {{namespace[ld]}}isrefvar}}<strong>LD Reference Variant</strong>{{#else}}<a href=\"javascript:void(0);\" onclick=\"var data = this.parentNode.__data__;data.getDataLayer().makeLDReference(data);\">Make LD Reference</a>{{/if}}<br>"
                                 },
                                 x_axis: { field: "{{namespace[assoc]}}position" },
                                 y_axis: {
@@ -306,30 +306,20 @@ LocusZoom.TransformationFunctions.add("percent", function(x) {
                         type: "resize_to_data",
                         position: "right",
                         color: "blue"
-                    }]
+                    }, LocusZoom.Layouts.get('toolbar_widgets', 'gene_selector_menu')]
                 },
                 data_layers: [
-                    LocusZoom.Layouts.get("data_layer", "genes", {
+                    LocusZoom.Layouts.get("data_layer", "genes_filtered", {
                         unnamespaced: true,
                         fields: ["{{namespace[gene]}}all"],
                         tooltip: {
-                            closable: true,
-                            show: {
-                                or: ["highlighted", "selected"]
-                            },
-                            hide: {
-                                and: ["unhighlighted", "unselected"]
-                            },
                             html: ("<h4><strong><i>{{gene_name}}</i></strong></h4>" +
                                    "<div>Gene ID: <strong>{{gene_id}}</strong></div>" +
                                    "<div>Transcript ID: <strong>{{transcript_id}}</strong></div>" +
                                    "<div style=\"clear: both;\"></div>" +
                                    "<table width=\"100%\"><tr><td style=\"text-align: right;\"><a href=\"http://gnomad.broadinstitute.org/gene/{{gene_id}}\" target=\"_new\">More data on gnomAD/ExAC</a> and <a href=\"http://bravo.sph.umich.edu/freeze5/hg38/gene/{{gene_id}}\" target=\"_new\">Bravo</a></td></tr></table>")
                         },
-                        label_exon_spacing: 3,
-                        exon_height: 8,
-                        bounding_box_padding: 5,
-                        track_vertical_spacing: 5
+
                     })
                 ],
             })

--- a/pheweb/serve/static/region.js
+++ b/pheweb/serve/static/region.js
@@ -31,6 +31,16 @@ LocusZoom.Adapters.extend("AssociationLZ", "AssociationPheWeb", {
             });
         }
         return LocusZoom.Adapters.get('AssociationLZ').prototype.extractFields.call(this, data, fields, outnames, trans);
+    },
+
+    normalizeResponse(data) {
+        // The PheWeb region API has a fun quirk where if there is no data, there are also no keys
+        //   (eg data = {} instead of  {assoc:[]} etc. Explicitly detect and handle the edge case in PheWeb;
+        //   we won't handle this in LZ core because we don't want squishy-blob API schemas to catch on.
+        if (!Object.keys(data).length) {
+            return [];
+        }
+        return LocusZoom.Adapters.get('AssociationLZ').prototype.normalizeResponse.call(this, data);
     }
 });
 

--- a/pheweb/serve/static/variant.js
+++ b/pheweb/serve/static/variant.js
@@ -81,7 +81,7 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
         return category_order[d.category];
     });
     window.unique_categories = d3.set(window.variant.phenos.map(_.property('category'))).values();
-    window.color_by_category = ((unique_categories.length>10) ? d3.scale.category20() : d3.scale.category10())
+    window.color_by_category = d3.scaleOrdinal((unique_categories.length > 10) ? d3.schemeCategory20 : d3.schemeCategory10)
         .domain(unique_categories);
 
     window.variant.phenos.forEach(function(d, i) {
@@ -101,29 +101,33 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
         if (x === 0) return best_neglog10_pval * 1.1;
         return -Math.log(x) / Math.LN10;
     };
-    LocusZoom.TransformationFunctions.set("neglog10_handle0", neglog10_handle0);
+    LocusZoom.TransformationFunctions.add("neglog10_handle0", neglog10_handle0);
 
     // Define data sources object
-    LocusZoom.Data.PheWASSource.prototype.getData = function(state, fields, outnames, trans) {
-        // Override all parsing, namespacing, and field extraction mechanisms, and load data embedded within the page
-        trans = trans || [];
+    // TODO: Can this be replaced with StaticSource + deepcopy?
+    LocusZoom.Adapters.extend('PheWASLZ', 'PheWebSource', {
+        getData: function(state, fields, outnames, trans) {
+            // Override all parsing, namespacing, and field extraction mechanisms, and load data embedded within the page
+            trans = trans || [];
 
-        var data = deepcopy(window.variant.phenos); //otherwise LZ adds attributes I don't want to the original data.
-        data.forEach(function(d, i) {
-            data[i].x = i;
-            data[i].id = i.toString();
-            trans.forEach(function(transformation, t){
-                if (typeof transformation === "function"){
-                    data[i][outnames[t]] = transformation(data[i][fields[t]]);
-                }
+            var data = deepcopy(window.variant.phenos); //otherwise LZ adds attributes I don't want to the original data.
+            data.forEach(function(d, i) {
+                data[i].x = i;
+                data[i].id = i.toString();
+                trans.forEach(function(transformation, t){
+                    if (typeof transformation === "function"){
+                        data[i][outnames[t]] = transformation(data[i][fields[t]]);
+                    }
+                });
             });
-        });
-        return function(chain) {
-            return {header: chain.header || {}, body: data};
-        }.bind(this);
-    };
+            return function(chain) {
+                return {header: chain.header || {}, body: data};
+            }.bind(this);
+        }
+    });
+
     var data_sources = new LocusZoom.DataSources()
-      .add("phewas", ["PheWASLZ", {url: '/this/is/not/used'}]);
+      .add("phewas", ["PheWebSource", {url: '/this/is/not/used'}]);
 
     var neglog10_significance_threshold = -Math.log10(0.05 / window.variant.phenos.length);
 
@@ -132,10 +136,13 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
             variant: ['chrom', 'pos', 'ref', 'alt'].map(function(d) { return window.variant[d];}).join("-"),
         },
         dashboard: {
-            components: [{type: "download", position: "right"}],
+            components: [
+                {type: "download", position: "right"},
+                {type: "download_png", position: "right"},
+            ],
         },
         min_height: 400,
-        responsive_resize: "width_only",
+        responsive_resize: true,
         mouse_guide: false,
         panels: [custom_LocusZoom_Layouts_get('panel', 'phewas', {
             min_width: 640, // feels reasonable to me
@@ -148,6 +155,7 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
                 custom_LocusZoom_Layouts_get('data_layer', 'phewas_pvalues', {
                     unnamespaced: true,
                     id_field: 'idx',
+                    type: 'scatter',
                     color: {
                         field: "category_name",
                         scale_function: "categorical_bin",
@@ -160,8 +168,8 @@ LocusZoom.ScaleFunctions.add("effect_direction", function(parameters, input){
                         {
                             scale_function: 'effect_direction',
                             parameters: {
-                                '+': 'triangle-up',
-                                '-': 'triangle-down'
+                                '+': 'triangle',
+                                '-': 'triangledown'
                             }
                         },
                         'circle'

--- a/pheweb/serve/static/variant.js
+++ b/pheweb/serve/static/variant.js
@@ -24,7 +24,7 @@ function custom_LocusZoom_Layouts_get(layout_type, layout_name, customizations) 
     return layout;
 }
 
-LocusZoom.TransformationFunctions.set("percent", function(x) {
+LocusZoom.TransformationFunctions.add("percent", function(x) {
     if (x === 1) { return "100%"; }
     x = (x * 100).toPrecision(2);
     if (x.indexOf('.') !== -1) { x = x.replace(/0+$/, ''); }

--- a/pheweb/serve/templates/gene.html
+++ b/pheweb/serve/templates/gene.html
@@ -9,14 +9,15 @@
   window.model.tooltip_lztemplate = {{ tooltip_lztemplate|tojson }};
 </script>
 {# Includes for LocusZoom.js (from CDN) #}
-<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
 <script src="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
 
 <script src="{{ url_for('.static', filename='vendor/stream_table-1.1.1.min.js') }}" type="text/javascript"></script>
+
+<link  href="{{ url_for('.static', filename='region.css') }}" rel="stylesheet" type="text/css">
 <script src="{{ url_for('.static', filename='region.js') }}" type="text/javascript"></script>
 <script src="{{ url_for('.static', filename='gene.js') }}" type="text/javascript"></script>
-<link  href="{{ url_for('.static', filename='region.css') }}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 

--- a/pheweb/serve/templates/gene.html
+++ b/pheweb/serve/templates/gene.html
@@ -9,9 +9,9 @@
   window.model.tooltip_lztemplate = {{ tooltip_lztemplate|tojson }};
 </script>
 {# Includes for LocusZoom.js (from CDN) #}
-<link href="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.vendor.min.js" type="text/javascript"></script>
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
+<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
+<script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
 
 <script src="{{ url_for('.static', filename='vendor/stream_table-1.1.1.min.js') }}" type="text/javascript"></script>
 <script src="{{ url_for('.static', filename='region.js') }}" type="text/javascript"></script>

--- a/pheweb/serve/templates/pheno-filter.html
+++ b/pheweb/serve/templates/pheno-filter.html
@@ -2,9 +2,8 @@
 
 
 {% block in_head %}
-{# include LocusZoom vendor bundle to get d3 #}
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.vendor.min.js" type="text/javascript"></script>
-<script src="https://unpkg.com/d3-tip@0.6.7/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
+<script src="https://unpkg.com/d3-tip@0.9.1"></script>
 <script src="{{ url_for('.static', filename='vendor/stream_table-1.1.1.min.js') }}" type="text/javascript"></script>
 <script src="{{ url_for('.static', filename='pheno-filter.js') }}" type="text/javascript"></script>
 

--- a/pheweb/serve/templates/pheno.html
+++ b/pheweb/serve/templates/pheno.html
@@ -3,8 +3,8 @@
 
 {% block in_head %}
 {# include LocusZoom vendor bundle to get d3 #}
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.vendor.min.js" type="text/javascript"></script>
-<script src="https://unpkg.com/d3-tip@0.6.7/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
+<script src="https://unpkg.com/d3-tip@0.9.1"></script>
 <script src="{{ url_for('.static', filename='vendor/stream_table-1.1.1.min.js') }}" type="text/javascript"></script>
 <script src="{{ url_for('.static', filename='pheno.js') }}" type="text/javascript"></script>
 {% if show_correlations %}

--- a/pheweb/serve/templates/pheno.html
+++ b/pheweb/serve/templates/pheno.html
@@ -2,7 +2,6 @@
 
 
 {% block in_head %}
-{# include LocusZoom vendor bundle to get d3 #}
 <script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
 <script src="https://unpkg.com/d3-tip@0.9.1"></script>
 <script src="{{ url_for('.static', filename='vendor/stream_table-1.1.1.min.js') }}" type="text/javascript"></script>

--- a/pheweb/serve/templates/phenotypes.html
+++ b/pheweb/serve/templates/phenotypes.html
@@ -77,7 +77,7 @@
       <% } else if (h.num_samples) { %>
         <%= h.num_samples.toLocaleString() %>
       <% } %>
-    <td><%= h.gc_lambda_hundred.toFixed(2) %></td>
+    <td><%= (h.gc_lambda_hundred !== null) ? h.gc_lambda_hundred.toFixed(2) : '' %></td>
     <td><%= h.num_peaks %></td>
     <td><a style="color:black" href="{{ url_for('.variant_page', query='').rstrip('/') }}/<%= h.chrom %>-<%= h.pos %>-<%= h.ref %>-<%= h.alt %>">
         <%= h.chrom %>:<%= h.pos.toLocaleString() %> <%= h.ref %> / <%= h.alt %>

--- a/pheweb/serve/templates/region.html
+++ b/pheweb/serve/templates/region.html
@@ -7,7 +7,7 @@
   window.model.tooltip_lztemplate = {{ tooltip_lztemplate|tojson }};
 </script>
 {# Includes for LocusZoom.js (from CDN) #}
-<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
 <script src="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
 

--- a/pheweb/serve/templates/region.html
+++ b/pheweb/serve/templates/region.html
@@ -7,9 +7,9 @@
   window.model.tooltip_lztemplate = {{ tooltip_lztemplate|tojson }};
 </script>
 {# Includes for LocusZoom.js (from CDN) #}
-<link href="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.vendor.min.js" type="text/javascript"></script>
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
+<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
+<script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
 
 <script src="{{ url_for('.static', filename='region.js') }}"></script>
 <link  href="{{ url_for('.static', filename='region.css') }}" rel="stylesheet" type="text/css">

--- a/pheweb/serve/templates/variant.html
+++ b/pheweb/serve/templates/variant.html
@@ -9,7 +9,7 @@
 <script src="{{ url_for('.static', filename='vendor/stream_table-1.1.1.min.js') }}" type="text/javascript"></script>
 
 {# Includes for LocusZoom.js (from CDN) #}
-<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
 <script src="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
 

--- a/pheweb/serve/templates/variant.html
+++ b/pheweb/serve/templates/variant.html
@@ -36,7 +36,7 @@
         <span id="maf-range"></span>
 {#        {% if variant.ac %}<p>AC: {{ variant.ac }}</p>{% endif %} #}
         <p>View on
-          <a href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg{{ config.HG_BUILD_NUMBER }}&highlight=hg{{ config.HG_BUILD_NUMBER }}.chr{{ variant.chrom }}%3A{ variant.pos }}-{{ variant.pos }}&position=chr{{ variant.chrom }}%3A{{ variant.pos - 200000 }}-{{ variant.pos + 200000 }}">UCSC</a>
+          <a href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg{{ config.HG_BUILD_NUMBER }}&highlight=hg{{ config.HG_BUILD_NUMBER }}.chr{{ variant.chrom }}%3A{{ variant.pos }}-{{ variant.pos }}&position=chr{{ variant.chrom }}%3A{{ variant.pos - 200000 }}-{{ variant.pos + 200000 }}">UCSC</a>
           {% with rsids = (variant.rsids.split(',') if variant.rsids else []) %}
             {% if rsids|length == 1 %}
               , <a href="https://www.ebi.ac.uk/gwas/search?query={{ rsids[0] }}">GWAS Catalog</a>

--- a/pheweb/serve/templates/variant.html
+++ b/pheweb/serve/templates/variant.html
@@ -9,9 +9,9 @@
 <script src="{{ url_for('.static', filename='vendor/stream_table-1.1.1.min.js') }}" type="text/javascript"></script>
 
 {# Includes for LocusZoom.js (from CDN) #}
-<link href="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION_PHEWAS }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION_PHEWAS }}/dist/locuszoom.vendor.min.js" type="text/javascript"></script>
-<script src="https://unpkg.com/locuszoom@{{ config.LZJS_VERSION_PHEWAS }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
+<link href="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.css" rel="stylesheet" type="text/css">
+<script src="https://cdn.jsdelivr.net/npm/d3@^5.16.0" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/locuszoom@{{ config.LZJS_VERSION }}/dist/locuszoom.app.min.js" type="text/javascript"></script>
 
 <script src="{{ url_for('.static', filename='variant.js') }}" type="text/javascript"></script>
 <style type="text/css">


### PR DESCRIPTION
# Purpose
Upgrade PheWeb to use the newest version of LocusZoom (0.13.0), and modify ancillary visualizations to work with the updated d3 dependency (v5).

During testing, some minor PheWeb bugs were found and fixed as well.

# Summary of changes
* New toolbar button on PheWas and region plots ("Save PNG"). So far, users appear to prefer this over SVG.
* New "filter genes" button; the genes track will now show as filtered to coding genes by default. This helps reduce crowding and focus the eye on most common targets.
* Template strings no longer assume 0 is truthy; use new `is_numeric` transformation func where appropriate
* Don't show "make ld reference" tooltip link if something is already the reference variant
* Uses LZ 0.13, so also gets access to things like performance enhancements for TOPMED scale data, display filters, "highlight region" track, gnomAD gene constraint data (grch37 only), etc

## Misc Bugfixes
* Some tables failed to render when there were a few missing gc lambda values
* Fix "highlight region" feature in "view on UCSC" variant links
* Use the same version of LZ on both "phewas" and "region" pages. These are no longer separate config options.
* Fix error messages when scrolling the plot area to a region with no SNPs
* Removed a small amount of dead code