### PR TITLE
Update PheWeb for changes in LZjs 0.14.0

### DIFF
--- a/pheweb/conf.py
+++ b/pheweb/conf.py
@@ -164,7 +164,7 @@ def get_pheno_correlations_pvalue_threshold() -> float: return _get_config_float
 
 
 ## Serving config
-def get_lzjs_version() -> str: return _get_config_str('lzjs_version', '0.13.0')
+def get_lzjs_version() -> str: return _get_config_str('lzjs_version', '0.14.0-beta.2')
 def should_allow_variant_json_cors() -> bool: return _get_config_bool('allow_variant_json_cors', True)
 def get_urlprefix() -> str: return _get_config_str('urlprefix', '').rstrip('/')
 def get_custom_templates_dir() -> Optional[str]:

--- a/pheweb/serve/server_utils.py
+++ b/pheweb/serve/server_utils.py
@@ -1,3 +1,4 @@
+import math
 
 from flask import url_for, Response, redirect
 
@@ -37,7 +38,10 @@ class _Get_Pheno_Region:
                 _Get_Pheno_Region._rename(v, 'chrom', 'chr')
                 _Get_Pheno_Region._rename(v, 'pos', 'position')
                 _Get_Pheno_Region._rename(v, 'rsids', 'rsid')
+                # TODO: Old PheWeb sends "pvalue", but new LocusZoom is trying to encourage use of log_pvalue (more resistant to underflow for really significant hits)
+                #  We will send both fields for now, but should consolidate this in future.
                 _Get_Pheno_Region._rename(v, 'pval', 'pvalue')
+                v['log_pvalue'] = -math.log10(v['pvalue'])
                 variants.append(v)
 
         df = _Get_Pheno_Region._dataframify(variants)

--- a/pheweb/serve/static/region.css
+++ b/pheweb/serve/static/region.css
@@ -8,7 +8,7 @@
     float: none !important;
 }
 /*
-TODO: merge toolbar-component-centering into LZ. (should it be the default?)
+TODO: merge toolbar-widget-centering into LZ. (should it be the default?)
       - if not, make it explicit.  it's bad that I'm just centering anything with `.lz-toolbar-group-*`.
 TODO: stop text-align:center from cascading downward through descendants
 */


### PR DESCRIPTION
🦑 Hold for final release of LZ 0.14.0

# Purpose
The next release of LocusZoom  makes breaking changes to how data is retrieved. This PR updates PheWeb to work with the new version, and introduces small user-facing benefits in terms of larger font sizes and a more concise legend for association plots. This will help people to use figures from PheWeb in publications or presentations.

# Blockers
Hold for the final release of LocusZoom.js 14, so that we can update the version string in this PR before merge. (I'm hoping that will happen soon)

# Testing notes
* The original data retrieval code was.... verbose. Let me know if I missed any edge cases
* I modified the API to send `log_pvalue` (instead of just pvalue). It seems silly to duplicate, and this could be fragile in cases of numerical underflow. Is there a pheweb branch that uses log pvalue internally? 
  *  Peter should check this section to make sure that very small pvalues don't trigger a python exception. I did not test thoroughly, because calculating log on the fly isn't my ideal solution (storing and sending things as log_pvalue seems more robust)