### PR TITLE
manhattan plot not show when NaN in variant_bins(json file)

### DIFF
--- a/pheweb/load/manhattan.py
+++ b/pheweb/load/manhattan.py
@@ -122,7 +122,7 @@ class Binner:
         pos_bin_id = variant['pos'] // BIN_LENGTH
         if pos_bin_id not in self._bins[chrom_idx]:
             self._bins[chrom_idx][pos_bin_id] = {'chrom': variant['chrom'], 'startpos': pos_bin_id * BIN_LENGTH, 'qvals': set()}
-        qval = math.inf if variant['pval'] == 0 else self._rounded(-math.log10(variant['pval']))
+        qval = self._rounded(320) if variant['pval'] == 0 else self._rounded(-math.log10(variant['pval']))
         self._bins[chrom_idx][pos_bin_id]["qvals"].add(qval)
 
     def get_result(self) -> Dict[str,List[Variant]]:


### PR DESCRIPTION
I run pheweb with my data, which some p value is 0, and manhattan plot
will not show if it json file contain NaN(jquery .getJSON failed). And
this value is generted by self._arounded(math.inf).