### PR TITLE
Universal Analytics is now depricated. 

### DIFF
--- a/etc/detailed-webserver-instructions.md
+++ b/etc/detailed-webserver-instructions.md
@@ -73,12 +73,12 @@ At this point your PheWeb should be working how you want it to, except maybe the
 
 ## Using Google Analytics
 
-Go [here](https://analytics.google.com/analytics/web) and do whatever you have to to get your own UA-xxxxxxxx-x tracking id.
+Go [here](https://analytics.google.com/analytics/web) and do whatever you have to to get your own tracking id (i.e. AW-XXXXX or G-XXXXX).
 
 Then, in `config.py`, set:
 
 ```
-GOOGLE_ANALYTICS_TRACKING_ID = 'UA-xxxxxxxx-x'
+GOOGLE_ANALYTICS_TRACKING_ID = 'G-XXXXX'
 ```
 
 and kill and restart `pheweb serve`.

--- a/pheweb/serve/templates/layout.html
+++ b/pheweb/serve/templates/layout.html
@@ -30,14 +30,12 @@
 {% endif %}
 
 {% if config['GOOGLE_ANALYTICS_TRACKING_ID'] %}
-  <script type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ config['GOOGLE_ANALYTICS_TRACKING_ID'] }}', 'auto');
-    ga('send', 'pageview');
-  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{config['GOOGLE_ANALYTICS_TRACKING_ID']}}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+  gtag('config', "{{config['GOOGLE_ANALYTICS_TRACKING_ID']}}");
 {% endif %}
 {% block in_head %}{% endblock %}
 </head>


### PR DESCRIPTION
This updated integrate with the previous methodology the current Google analytics set-up. See https://support.google.com/analytics/answer/11583528?hl=en for further information